### PR TITLE
feat: move activities storage to persistent SQLite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 *.log
 *.sql
 *.sqlite
+*.db
 
 # OS generated files #
 ######################

--- a/src/README.md
+++ b/src/README.md
@@ -6,19 +6,20 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Persist activities and registrations in SQLite
 
 ## Getting Started
 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r ../requirements.txt
    ```
 
 2. Run the application:
 
    ```
-   python app.py
+   uvicorn app:app --reload
    ```
 
 3. Open your browser and go to:
@@ -47,4 +48,4 @@ The application uses a simple data model with meaningful identifiers:
    - Name
    - Grade level
 
-All data is stored in memory, which means data will be reset when the server restarts.
+Data is stored in SQLite (`src/activities.db`), so signups remain after server restarts.

--- a/src/app.py
+++ b/src/app.py
@@ -8,6 +8,7 @@ for extracurricular activities at Mergington High School.
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+import sqlite3
 import os
 from pathlib import Path
 
@@ -19,8 +20,11 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
+# SQLite database path
+DB_PATH = current_dir / "activities.db"
+
+# Initial data used to seed the database on first run
+INITIAL_ACTIVITIES = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -78,6 +82,120 @@ activities = {
 }
 
 
+def get_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db() -> None:
+    with get_connection() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS activities (
+                name TEXT PRIMARY KEY,
+                description TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                max_participants INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS registrations (
+                activity_name TEXT NOT NULL,
+                email TEXT NOT NULL,
+                PRIMARY KEY (activity_name, email),
+                FOREIGN KEY (activity_name) REFERENCES activities (name) ON DELETE CASCADE
+            )
+            """
+        )
+        conn.commit()
+
+
+def seed_db_if_empty() -> None:
+    with get_connection() as conn:
+        existing_count = conn.execute(
+            "SELECT COUNT(*) FROM activities"
+        ).fetchone()[0]
+        if existing_count > 0:
+            return
+
+        for name, activity in INITIAL_ACTIVITIES.items():
+            conn.execute(
+                """
+                INSERT INTO activities (name, description, schedule, max_participants)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    name,
+                    activity["description"],
+                    activity["schedule"],
+                    activity["max_participants"],
+                ),
+            )
+
+            for email in activity["participants"]:
+                conn.execute(
+                    """
+                    INSERT INTO registrations (activity_name, email)
+                    VALUES (?, ?)
+                    """,
+                    (name, email),
+                )
+
+        conn.commit()
+
+
+def activity_exists(conn: sqlite3.Connection, activity_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM activities WHERE name = ?",
+        (activity_name,),
+    ).fetchone()
+    return row is not None
+
+
+def load_activities_from_db() -> dict:
+    with get_connection() as conn:
+        activity_rows = conn.execute(
+            """
+            SELECT name, description, schedule, max_participants
+            FROM activities
+            ORDER BY name
+            """
+        ).fetchall()
+
+        registrations_by_activity = {}
+        for registration_row in conn.execute(
+            """
+            SELECT activity_name, email
+            FROM registrations
+            ORDER BY activity_name, email
+            """
+        ).fetchall():
+            registrations_by_activity.setdefault(
+                registration_row["activity_name"], []
+            ).append(registration_row["email"])
+
+    activities = {}
+    for row in activity_rows:
+        name = row["name"]
+        activities[name] = {
+            "description": row["description"],
+            "schedule": row["schedule"],
+            "max_participants": row["max_participants"],
+            "participants": registrations_by_activity.get(name, []),
+        }
+
+    return activities
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+    seed_db_if_empty()
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -85,48 +203,74 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return load_activities_from_db()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as conn:
+        # Validate activity exists
+        if not activity_exists(conn, activity_name):
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        # Validate student is not already signed up
+        existing = conn.execute(
+            """
+            SELECT 1
+            FROM registrations
+            WHERE activity_name = ? AND email = ?
+            """,
+            (activity_name, email),
+        ).fetchone()
+        if existing is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is already signed up"
+            )
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
+        conn.execute(
+            """
+            INSERT INTO registrations (activity_name, email)
+            VALUES (?, ?)
+            """,
+            (activity_name, email),
         )
+        conn.commit()
 
-    # Add student
-    activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as conn:
+        # Validate activity exists
+        if not activity_exists(conn, activity_name):
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        # Validate student is signed up
+        existing = conn.execute(
+            """
+            SELECT 1
+            FROM registrations
+            WHERE activity_name = ? AND email = ?
+            """,
+            (activity_name, email),
+        ).fetchone()
+        if existing is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is not signed up for this activity"
+            )
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
+        conn.execute(
+            """
+            DELETE FROM registrations
+            WHERE activity_name = ? AND email = ?
+            """,
+            (activity_name, email),
         )
+        conn.commit()
 
-    # Remove student
-    activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}


### PR DESCRIPTION
## Summary
Implements issue #9 by migrating activity/registration data from in-memory storage to SQLite persistence while preserving current API behavior.

## Changes
- Replace in-memory `activities` dict reads/writes with SQLite-backed storage
- Add DB initialization and first-run seed logic on app startup
- Add `activities` and `registrations` tables
- Keep endpoint contracts unchanged for:
  - `GET /activities`
  - `POST /activities/{activity_name}/signup`
  - `DELETE /activities/{activity_name}/unregister`
- Update docs in `src/README.md` to reflect persistence and startup command
- Add `*.db` to `.gitignore` to avoid committing runtime database artifacts

## Validation
- Verified signup/unregister still work with DB backend
- Verified data persists across process restarts
- Verified cleanup of test registration record

Closes #9